### PR TITLE
Create submit response listener on server

### DIFF
--- a/db/db-queries.js
+++ b/db/db-queries.js
@@ -15,3 +15,8 @@ module.exports.setGameInstanceGameStageToPlaying = function(gameName) {
 
   return games.update({gameName: gameName}, {gameStage: 'playing'});
 };
+
+module.exports.updateRounds = function(gameName, roundsArray) {
+
+  return games.update({gameName: gameName}, {rounds: roundsArray});
+}

--- a/server/helpers.js
+++ b/server/helpers.js
@@ -1,0 +1,14 @@
+
+var userAlreadySubmitted = function(username, responseArray) {
+  var submitted = false;
+
+  for (var i = 0; i < responseArray.length; i++) {
+    if (responseArray[i][1] === username) {
+      submitted = true;
+    }
+  }
+
+  return submitted;
+}
+
+module.exports.userAlreadySubmitted = userAlreadySubmitted;


### PR DESCRIPTION
Server should listen for a 'submit response' socket event. When it hears the event, it should retrieve the corresponding game instance from the DB and update it if that user has not yet responded. If there are now 3 responses for that round, the server should then emit a socket event called 'start judging', sending along the updated game instance object.