### PR TITLE
Add socket event to update Waiting Room

### DIFF
--- a/client/src/components/Game.jsx
+++ b/client/src/components/Game.jsx
@@ -19,6 +19,9 @@ class Game extends React.Component {
     this.handleJudgeSelection = this.handleJudgeSelection.bind(this);
     this.handleReadyToMoveOn = this.handleReadyToMoveOn.bind(this);
 
+    socket.on('update waiting room', (gameObj) => {
+      this.setState({game: gameObj});
+    })
     socket.on('start game', (gameObj) => {
       this.setState({game: gameObj});
     })
@@ -110,7 +113,7 @@ class Game extends React.Component {
       <div id="game">
         <h4>Game!</h4>
         {this.props.params.gamename}
-        {this.state.game && this.state.game.gameStage === 'waiting' && <WaitingRoom numPlayers={this.state.game.players.length} players={this.state.game.players}/>}
+        {this.state.game && this.state.username && this.state.game.gameStage === 'waiting' && <WaitingRoom players={this.state.game.players} user={this.state.username}/>}
         {this.state.game && this.state.username && this.state.game.gameStage === 'playing' && <PlayingGame game={this.state.game} user={this.state.username} handleResponse={this.handleResponse} handleJudgeSelection={this.handleJudgeSelection} handleReadyToMoveOn={this.handleReadyToMoveOn}/>}
       </div>
     )

--- a/client/src/components/WaitingRoom.jsx
+++ b/client/src/components/WaitingRoom.jsx
@@ -1,9 +1,10 @@
 import React from 'react';
 
+
 const WaitingRoom = (props) => (
   <div id='waiting-room'>
     <h4>Waiting Room</h4>
-    <h4>Number of Players: {props.numPlayers} / 4</h4>
+    <h4>Number of Players: {props.players.length} / 4</h4>
     <ol>Players:
       {props.players.map( (player) => <li>{player}</li>)}
     </ol>

--- a/server/index.js
+++ b/server/index.js
@@ -116,7 +116,10 @@ io.on('connection', (socket) => {
             io.to(gameName).emit('start game', game);
           })
         });
-      } 
+      } else {
+        console.log('joined, game: ', game);
+        io.to(gameName).emit('update waiting room', game);
+      }
     }).catch(function(error) {
       console.log(error)
       throw error;


### PR DESCRIPTION
When a user joins a game and there are not yet 4 players, server will emit 'update waiting room' socket event. When the client hears this socket event, it will re-set state with the updated game instance object which will then render the updated Waiting Room for the user.