### PR TITLE
(fix) Tell node to use strict

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "server/index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "node server/index.js",
+    "start": "node --use_strict server/index.js",
     "react-dev": "webpack -d --watch",
     "server-dev": "nodemon server/index.js"
   },


### PR DESCRIPTION
Error from Heroku logs: 'SyntaxError: Block-scoped declarations
(let, const, function, class) not yet supported outside strict mode'

If this fix works, I'll go back and update the indivdual files
to use strict.