### PR TITLE
(fix) Update urls to refer to localhost:3000

### DIFF
--- a/client/src/components/CreateGame.jsx
+++ b/client/src/components/CreateGame.jsx
@@ -28,7 +28,7 @@ class CreateGame extends React.Component {
     }
 
     $.ajax({
-      url: 'https://orange-to-orange-staging.herokuapp.com/games',
+      url: 'http://localhost:3000/games',
       method: 'POST',
       headers: {'content-type': 'application/json'},
       data: JSON.stringify(gameInstance),

--- a/client/src/components/Game.jsx
+++ b/client/src/components/Game.jsx
@@ -67,7 +67,7 @@ class Game extends React.Component {
   getGameData(gameName) {
     // use gameName to retrieve gameInstance obj of that game
     $.ajax({
-      url: 'https://orange-to-orange-staging.herokuapp.com/game',
+      url: 'http://localhost:3000/game',
       method: 'GET',
       headers: {'content-type': 'application/json'},
       data: {name: gameName},
@@ -82,7 +82,7 @@ class Game extends React.Component {
 
   getUsername() {
     $.ajax({
-      url: 'https://orange-to-orange-staging.herokuapp.com/username',
+      url: 'http://localhost:3000/username',
       method: 'GET',
       headers: {'content-type': 'application/json'},
       success: (username) => {

--- a/client/src/components/Lobby.jsx
+++ b/client/src/components/Lobby.jsx
@@ -22,7 +22,7 @@ class Lobby extends React.Component {
 
   getGames() {
     $.ajax({
-      url: 'https://orange-to-orange-staging.herokuapp.com/games',
+      url: 'http://localhost:3000/games',
       method: 'GET',
       headers: {'content-type': 'application/json'},
       success: (data) => {

--- a/client/src/components/LogIn.jsx
+++ b/client/src/components/LogIn.jsx
@@ -28,7 +28,7 @@ class LogIn extends React.Component {
 
   handleLogInAttempt(username, password) {
     $.ajax({
-      url: 'https://orange-to-orange-staging.herokuapp.com/login',
+      url: 'http://localhost:3000/login',
       method: 'POST',
       headers: {'content-type': 'application/json'},
       data: JSON.stringify({'username': username, 'password': password}),

--- a/client/src/components/SignUp.jsx
+++ b/client/src/components/SignUp.jsx
@@ -35,7 +35,7 @@ class SignUp extends React.Component {
 
   handleSignUpAttempt(email, username, password) {
     $.ajax({
-      url: 'https://orange-to-orange-staging.herokuapp.com/signup',
+      url: 'http://localhost:3000/signup',
       method: 'POST',
       headers: {'content-type': 'application/json'},
       data: JSON.stringify({'username': username, 'email': email, 'password': password}),


### PR DESCRIPTION
Bug has been identified, will need further research.

Heroku error:
 at=error code=H12 desc="Request timeout" method=POST path="/signup" host=orange-to-orange-staging.herokuapp.com request_id=8caac93a-44d1-42b1-8e81-acc8d676eeb9 fwd="108.209.105.97" dyno=web.1 connect=0ms service=30000ms status=503 bytes=0 protocol=https