### PR TITLE
Feat/end of game

### DIFF
--- a/client/src/components/EndOfGame.jsx
+++ b/client/src/components/EndOfGame.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import Score from './Score.jsx';
+import RoundSummary from './RoundSummary.jsx';
+
+const EndOfGame = (props) => {
+
+	return (
+	  <div id='EndOfGame'>
+	    <h4>Game Over</h4>
+	    <h3>Final Score</h3>
+	    <Score game={props.game} />
+	    <h4>Number of Players: {props.players.length} / 4</h4>
+	    <ol>Players:
+	      {props.players.map( (player) => <li>{player}</li>)}
+	    </ol>
+	  </div>
+	)
+
+}
+
+export default EndOfGame;

--- a/client/src/components/EndOfGame.jsx
+++ b/client/src/components/EndOfGame.jsx
@@ -1,18 +1,19 @@
 import React from 'react';
-import Score from './Score.jsx';
+import Score from './PlayingGameComponents/Score.jsx';
 import RoundSummary from './RoundSummary.jsx';
 
 const EndOfGame = (props) => {
+
 
 	return (
 	  <div id='EndOfGame'>
 	    <h4>Game Over</h4>
 	    <h3>Final Score</h3>
 	    <Score game={props.game} />
-	    <h4>Number of Players: {props.players.length} / 4</h4>
-	    <ol>Players:
-	      {props.players.map( (player) => <li>{player}</li>)}
-	    </ol>
+	    <RoundSummary round={props.game.rounds[3]} judge={props.game.players[3]}/>
+	    <RoundSummary round={props.game.rounds[2]} judge={props.game.players[2]}/>
+	    <RoundSummary round={props.game.rounds[1]} judge={props.game.players[1]}/>
+	    <RoundSummary round={props.game.rounds[0]} judge={props.game.players[0]}/>
 	  </div>
 	)
 

--- a/client/src/components/Game.jsx
+++ b/client/src/components/Game.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import WaitingRoom from './WaitingRoom.jsx';
 import PlayingGame from './PlayingGame.jsx';
+import EndOfGame from './EndOfGame.jsx';
 import $ from 'jquery';
 import io from 'socket.io-client';
 const socket = io();
@@ -115,6 +116,7 @@ class Game extends React.Component {
         {this.props.params.gamename}
         {this.state.game && this.state.username && this.state.game.gameStage === 'waiting' && <WaitingRoom players={this.state.game.players} user={this.state.username}/>}
         {this.state.game && this.state.username && this.state.game.gameStage === 'playing' && <PlayingGame game={this.state.game} user={this.state.username} handleResponse={this.handleResponse} handleJudgeSelection={this.handleJudgeSelection} handleReadyToMoveOn={this.handleReadyToMoveOn}/>}
+        {this.state.game && this.state.username && this.state.game.gameStage === 'gameover' && <EndOfGame game={this.state.game}/>}
       </div>
     )
   }

--- a/client/src/components/RoundSummary.jsx
+++ b/client/src/components/RoundSummary.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+const RoundSummary = (props) => (
+  <div id="RoundSummary">
+  <div>
+  	'Judge: '{props.Judge} 'Prompt: ' {props.prompt}
+  </div>
+  	{props.responses.map((response) => (
+  			<div> 
+  				{response[1] === props.winner && 'WON: ' }{response[0]} {response[1]}  
+  			</div>
+  		))}
+  </div>
+)
+
+
+export default RoundSummary

--- a/client/src/components/RoundSummary.jsx
+++ b/client/src/components/RoundSummary.jsx
@@ -3,11 +3,11 @@ import React from 'react';
 const RoundSummary = (props) => (
   <div id="RoundSummary">
   <div>
-  	'Judge: '{props.Judge} 'Prompt: ' {props.prompt}
+  	'Judge: '{props.judge} 'Prompt: ' {props.round.prompt}
   </div>
-  	{props.responses.map((response) => (
+  	{props.round.responses.map((response) => (
   			<div> 
-  				{response[1] === props.winner && 'WON: ' }{response[0]} {response[1]}  
+  				{response[1] === props.round.winner && 'WON: ' }{response[0]} {response[1]}  
   			</div>
   		))}
   </div>

--- a/client/src/components/RoundSummary.jsx
+++ b/client/src/components/RoundSummary.jsx
@@ -3,13 +3,13 @@ import React from 'react';
 const RoundSummary = (props) => (
   <div id="RoundSummary">
   <div>
-  	'Judge: '{props.judge} 'Prompt: ' {props.round.prompt}
+    'Judge: '{props.judge} 'Prompt: ' {props.round.prompt}
   </div>
-  	{props.round.responses.map((response) => (
-  			<div> 
-  				{response[1] === props.round.winner && 'WON: ' }{response[0]} {response[1]}  
-  			</div>
-  		))}
+    {props.round.responses.map((response) => (
+        <div> 
+          {response[1] === props.round.winner && 'WON: ' }{response[0]} {response[1]}  
+        </div>
+      ))}
   </div>
 )
 

--- a/db/db-queries.js
+++ b/db/db-queries.js
@@ -24,3 +24,8 @@ module.exports.updateCurrentRound = function(gameName, round) {
 
   return games.update({gameName: gameName}, { $set: {currentRound: round} });
 }
+
+module.exports.setGameInstanceGameStageToGameOver = function(gameName) {
+
+  return games.update({gameName: gameName}, { $set: {gameStage: 'gameover'} });
+};

--- a/server/index.js
+++ b/server/index.js
@@ -210,7 +210,12 @@ io.on('connection', (socket) => {
               io.to(gameName).emit('winner chosen', game);
             } else {
               console.log('game over');
-              io.to(gameName).emit('game over', game);
+              queries.setGameInstanceGameStageToGameOver(gameName).then(function () {
+                queries.retrieveGameInstance(gameName).then(function (game) {
+                  console.log('gamemover', game);
+                  io.to(gameName).emit('game over', game);
+                })
+              })
             }
           })
         })


### PR DESCRIPTION
End of Game Component: Displays the final score and  all prompts, responses, judges, and winners of all four rounds.

RoundSummary component: displays the prompt, judge, responses and winner for a given round.

setGameInstanceGameStageToGameOver: Helper function in db-queries to update the game stage to 'gameover' 

Updated socket.on('judge selection') to properly display the end of game component at the end of judge selection during round 3. 

To be added on next pull request: Button to return to lobby at the bottom of EndOfGame component