### PR TITLE
Feat/response styling

### DIFF
--- a/client/dist/styles.css
+++ b/client/dist/styles.css
@@ -12,3 +12,8 @@ body {
 #create-game {
   align-items: center;
 }
+
+#prompt {
+  font-size: 18px;
+  
+}

--- a/client/dist/styles.css
+++ b/client/dist/styles.css
@@ -15,5 +15,4 @@ body {
 
 #prompt {
   font-size: 18px;
-  
 }

--- a/client/src/components/PlayingGame.jsx
+++ b/client/src/components/PlayingGame.jsx
@@ -7,7 +7,8 @@ import Winner from './PlayingGameComponents/Winner.jsx'
 import RespondToPrompt from './PlayingGameComponents/RespondToPrompt.jsx';
 import ChooseWinner from './PlayingGameComponents/ChooseWinner.jsx';
 import Score from './PlayingGameComponents/Score.jsx';
-// this.props.game = game instance object
+import { Col, PageHeader, ListGroup, ListGroupItem } from 'react-bootstrap';
+
 
 class PlayingGame extends React.Component{
   constructor(props) {
@@ -57,8 +58,8 @@ class PlayingGame extends React.Component{
     var winner = this.props.game.rounds[curRound].winner;
 
     return (
-      <div id="playing-game">
-        <h2>Playing Game</h2>
+      <Col id="playing-game">
+        <PageHeader>{this.props.game.gameName}: <small>Round {this.props.game.currentRound + 1}</small></PageHeader>
         <div>
           <Score game={this.props.game}/>
           <CurrentJudge judge={curJudge} />
@@ -71,7 +72,7 @@ class PlayingGame extends React.Component{
         {stage === 1 && this.state.role === 'player' && <SeeResponses responses={responses}/>}
         {stage === 2 && <Winner responses={responses} winner={winner} handleReadyToMoveOn={this.props.handleReadyToMoveOn}/>}
         </div>
-      </div>
+      </Col>
     )
   }
 }

--- a/client/src/components/PlayingGame.jsx
+++ b/client/src/components/PlayingGame.jsx
@@ -61,7 +61,9 @@ class PlayingGame extends React.Component{
       <Col id="playing-game">
         <PageHeader>{this.props.game.gameName}: <small>Round {this.props.game.currentRound + 1}</small></PageHeader>
         <div>
-          <Score game={this.props.game}/>
+          <Col sm={6} smOffset={3}>
+            <Score game={this.props.game}/>
+          </Col>
           <CurrentJudge judge={curJudge} />
           <Prompt prompt={curPrompt}/>
         </div>

--- a/client/src/components/PlayingGame.jsx
+++ b/client/src/components/PlayingGame.jsx
@@ -59,21 +59,21 @@ class PlayingGame extends React.Component{
 
     return (
       <Col id="playing-game">
-        <PageHeader>{this.props.game.gameName}: <small>Round {this.props.game.currentRound + 1}</small></PageHeader>
-        <div>
+        <PageHeader>{this.props.game.gameName}: <small>Round {this.props.game.currentRound + 1} - Judge: {curJudge}</small></PageHeader>
           <Col sm={6} smOffset={3}>
+            <h4>Scoreboard</h4>
             <Score game={this.props.game}/>
           </Col>
-          <CurrentJudge judge={curJudge} />
-          <Prompt prompt={curPrompt}/>
-        </div>
-        <div>
+          <Col sm={8} smOffset={2}>
+            <Prompt prompt={curPrompt}/>
+          </Col>
+        <Col sm={6} smOffset={3}>
         {stage === 0 && this.state.role === 'judge' && <PlayersResponding />}
         {stage === 0 && this.state.role === 'player' && <RespondToPrompt handleResponse={this.props.handleResponse}/>}
         {stage === 1 && this.state.role === 'judge' && <ChooseWinner responses={responses} handleJudgeSelection={this.props.handleJudgeSelection}/>}
         {stage === 1 && this.state.role === 'player' && <SeeResponses responses={responses}/>}
         {stage === 2 && <Winner responses={responses} winner={winner} handleReadyToMoveOn={this.props.handleReadyToMoveOn}/>}
-        </div>
+        </Col>
       </Col>
     )
   }

--- a/client/src/components/PlayingGame.jsx
+++ b/client/src/components/PlayingGame.jsx
@@ -67,7 +67,7 @@ class PlayingGame extends React.Component{
           <Col sm={8} smOffset={2}>
             <Prompt prompt={curPrompt}/>
           </Col>
-        <Col sm={6} smOffset={3}>
+        <Col sm={8} smOffset={2}>
         {stage === 0 && this.state.role === 'judge' && <PlayersResponding />}
         {stage === 0 && this.state.role === 'player' && <RespondToPrompt handleResponse={this.props.handleResponse}/>}
         {stage === 1 && this.state.role === 'judge' && <ChooseWinner responses={responses} handleJudgeSelection={this.props.handleJudgeSelection}/>}

--- a/client/src/components/PlayingGame.jsx
+++ b/client/src/components/PlayingGame.jsx
@@ -64,10 +64,10 @@ class PlayingGame extends React.Component{
             <h4>Scoreboard</h4>
             <Score game={this.props.game}/>
           </Col>
-          <Col sm={8} smOffset={2}>
+          <Col sm={6} smOffset={3}>
             <Prompt prompt={curPrompt}/>
           </Col>
-        <Col sm={8} smOffset={2}>
+        <Col sm={6} smOffset={3}>
         {stage === 0 && this.state.role === 'judge' && <PlayersResponding />}
         {stage === 0 && this.state.role === 'player' && <RespondToPrompt handleResponse={this.props.handleResponse}/>}
         {stage === 1 && this.state.role === 'judge' && <ChooseWinner responses={responses} handleJudgeSelection={this.props.handleJudgeSelection}/>}

--- a/client/src/components/PlayingGameComponents/CurrentJudge.jsx
+++ b/client/src/components/PlayingGameComponents/CurrentJudge.jsx
@@ -1,9 +1,12 @@
 import React from 'react';
+import { Panel, Col } from 'react-bootstrap';
 
 const CurrentJudge = (props) => (
-  <div id="current-judge">
-    <b>Judge: </b> {props.judge}
-  </div>
+  <Col sm={6} smOffset={3} id="current-judge">
+    <Panel>
+      <b>Current Judge: </b> {props.judge}
+    </Panel>
+  </Col>
 )
 
 

--- a/client/src/components/PlayingGameComponents/Prompt.jsx
+++ b/client/src/components/PlayingGameComponents/Prompt.jsx
@@ -1,9 +1,12 @@
 import React from 'react';
+import { Col, Panel } from 'react-bootstrap';
 
 const Prompt = (props) => (
-  <div id="prompt">
-    <b>Prompt: </b> {props.prompt}
-  </div>
+  <Col id="prompt">
+    <Panel>
+      <b>Prompt: </b>{props.prompt}
+    </Panel>
+  </Col>
 )
 
 

--- a/client/src/components/PlayingGameComponents/Prompt.jsx
+++ b/client/src/components/PlayingGameComponents/Prompt.jsx
@@ -6,6 +6,7 @@ const Prompt = (props) => (
     <Panel>
       <b>Prompt: </b>{props.prompt}
     </Panel>
+    <br />
   </Col>
 )
 

--- a/client/src/components/PlayingGameComponents/RespondToPrompt.jsx
+++ b/client/src/components/PlayingGameComponents/RespondToPrompt.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Col, Button, Form, FormGroup, ControlLabel, FormControl } from 'react-bootstrap';
 
 class RespondToPrompt extends React.Component {
   constructor(props) {
@@ -18,19 +19,30 @@ class RespondToPrompt extends React.Component {
   }
 
   render() {
+
+    const responseForm = (
+      <Form inline>
+        <FormGroup controlId="formInlineResponse" bsSize="large">
+          <FormControl type="text" placeholder="Your Response..." onChange={this.handleInputChange} value={this.state.response}/>
+        </FormGroup>
+        {' '}
+        <Button onClick={() => {
+            this.setState({responded: true});
+            this.props.handleResponse(this.state.response);
+          }
+        }>
+          Submit
+        </Button>
+      </Form>
+    )
+
+
+
     return (
-      <div id="choose-username">
-          {!this.state.responded && <b>Submit Response:</b> && <input type="text" value={this.state.value} onChange={this.handleInputChange} />}
-          {!this.state.responded && <button onClick={() => {
-              console.log('this: ', this);
-              this.setState({
-                responded: true
-              })
-              this.props.handleResponse(this.state.response)
-            }
-          }>Submit</button>}
+      <Col id="submit-response">
+          {!this.state.responded && responseForm}
           {this.state.responded && <p><b>Your response has been submitted!</b></p>}
-      </div>
+      </Col>
     )
   }
 }

--- a/client/src/components/PlayingGameComponents/Score.jsx
+++ b/client/src/components/PlayingGameComponents/Score.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Table } from 'react-bootstrap';
 
 class Score extends React.Component {
   constructor(props) {
@@ -10,22 +11,37 @@ class Score extends React.Component {
     let players = this.props.game.players;
     let rounds = this.props.game.rounds;
     let scores = {};
+
     players.forEach(function(player) {
       scores[player] = 0;
     });
+
     rounds.forEach(function(round) {
       if (round.winner.length > 0) {
         scores[round.winner]++;
       }
     });
+
     return (
-      <div id="score">
-      <div><strong>Scores!</strong></div>
-      {Object.keys(scores).map((username) => 
-        <div> {username}: {scores[username]} </div>
-        )}
-      </div>
+      <Table striped bordered condensed hover>
+        <tbody>
+          <tr>
+            {Object.keys(scores).map((username) =>
+              <td>{username}: {scores[username]} </td>
+            )}
+          </tr>
+        </tbody>
+      </Table>
     )
+
+    // return (
+    //   <div id="score">
+    //   <div><strong>Scores!</strong></div>
+    //   {Object.keys(scores).map((username) => 
+    //     <div> {username}: {scores[username]} </div>
+    //     )}
+    //   </div>
+    // )
   }
 }
 

--- a/client/src/components/PlayingGameComponents/Score.jsx
+++ b/client/src/components/PlayingGameComponents/Score.jsx
@@ -27,7 +27,7 @@ class Score extends React.Component {
         <tbody>
           <tr>
             {Object.keys(scores).map((username) =>
-              <td>{username}: {scores[username]} </td>
+              <td><b>{username}</b>: {scores[username]} </td>
             )}
           </tr>
         </tbody>


### PR DESCRIPTION
I added styling to the RespondToPrompt page which involved re-arranging some components in the PlayingGame component. I moved the current Judge info to be in the header which will update for each new round, so if we do it this way we will no longer need the currentJudge component. I thought it made sense to put it in the header rather than having another component below the header, but let me know if you don't like how that looks.

Also rearranged the PlayingGame component into different columns - one for the Score, one for the current prompt, and one for the round-stage-specific components. Here's a picture of what it looks like, let me know if you'd like anything changed: 

![screen shot 2017-03-25 at 4 27 24 pm](https://cloud.githubusercontent.com/assets/19918128/24326969/8b098ec4-1178-11e7-9861-b0be2f80ffdb.png)
