### PR TITLE
Feat/server handle disconnect

### DIFF
--- a/client/src/components/Game.jsx
+++ b/client/src/components/Game.jsx
@@ -40,6 +40,10 @@ class Game extends React.Component {
     socket.on('game over', (gameObj) => {
       this.setState({game: gameObj});
     })
+    socket.on('disconnectTimeOut', () => {
+      console.log('disconnectTimeOut')
+      this.props.route.sendToLobby.call(this, true);
+    })
 
   }
 

--- a/client/src/components/Lobby.jsx
+++ b/client/src/components/Lobby.jsx
@@ -3,6 +3,7 @@ import GameList from './GameList.jsx';
 import $ from 'jquery';
 import CreateGame from './CreateGame.jsx';
 import YourGames from './YourGames.jsx';
+import PlayerDisconnected from './PlayerDisconnected.jsx'
 import { Button, Form, FormGroup, Col, FormControl, ControlLabel, PageHeader } from 'react-bootstrap';
 
 
@@ -60,6 +61,7 @@ class Lobby extends React.Component {
 
       <Col id="lobby" sm={6} smOffset={3}>
         <PageHeader>Lobby</PageHeader>
+        {this.props.params.disconnectTimeOut && <PlayerDisconnected/>}
         <CreateGame sendToGame={this.props.route.sendToGame}/>
         {this.state.games && <YourGames games={this.state.games} username={this.state.username} sendToGame={this.props.route.sendToGame}/>}
         <h4>Current Games:</h4>

--- a/client/src/components/PlayerDisconnected.jsx
+++ b/client/src/components/PlayerDisconnected.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+const PlayerDisconnected = () => (
+  <div id="player-disconnected">
+    <h3>Our apologies, a player left your game so it ended early.</h3>
+    <br/>
+  </div>
+)
+
+
+export default PlayerDisconnected;

--- a/client/src/index.jsx
+++ b/client/src/index.jsx
@@ -17,8 +17,12 @@ class App extends React.Component {
       this.sendToLobby = this.sendToLobby.bind(this);
     }
 
-    sendToLobby() {
-      hashHistory.push('/lobby');
+    sendToLobby(disconnectTimeOut) {
+      if (disconnectTimeOut) {
+        hashHistory.push('/lobby/:disconnectTimeOut');
+      } else {
+        hashHistory.push('/lobby');
+      }
     }
 
     sendToGame(gameName) {
@@ -30,7 +34,8 @@ class App extends React.Component {
         <div>
           <Router history={hashHistory}>
             <Route path="/" component={Home} sendToLobby={this.sendToLobby} handleSignUp={this.handleSignUp} handleLogIn={this.handleLogIn}/>
-            <Route path="/lobby" component={Lobby} sendToGame={this.sendToGame}/>
+            <Route path="/lobby" component={Lobby} sendToGame={this.sendToGame} disconnectTimeOut={this.state.disconnectTimeOut}/>
+            <Route path="/lobby/:disconnectTimeOut" component={Lobby} sendToGame={this.sendToGame} disconnectTimeOut={this.state.disconnectTimeOut}/>
             <Route path="/game/:gamename" component={Game} sendToLobby={this.sendToLobby}/>
           </Router>
         </div>

--- a/server/index.js
+++ b/server/index.js
@@ -99,6 +99,9 @@ var server = app.listen(port, function() {
 
 var io = require('socket.io')(server);
 
+var Sockets = {};
+var Rooms = {};
+
 io.on('connection', (socket) => {
   console.log('a user connected to the socket');
 
@@ -108,6 +111,10 @@ io.on('connection', (socket) => {
     socket.join(data.gameName);
     let username = data.username;
     let gameName = data.gameName;
+    Sockets[socket] = gameName;
+    console.log(Sockets[socket]);
+    Rooms[gameName] ? Rooms[gameName]++ : Rooms[gameName] = 1;
+    console.log(Rooms[gameName]);
     queries.retrieveGameInstance(gameName)
     .then(function (game){
     // add client to game DB if they're not already in players list
@@ -270,8 +277,34 @@ io.on('connection', (socket) => {
   })
 
 
-  socket.on('disconnect', () => {
-    console.log('a user disconnected');
+  socket.on('disconnect', (data) => {
+    if (Rooms[Sockets[socket]]) {
+      Rooms[Sockets[socket]]--;
+      let timer = 60;
+      var disconnectTimeOut = function() {
+        setTimeout(function(){
+          if (timer === 0 && Rooms[Sockets[socket]] < 4) {
+            console.log('disconnectTimeOut')
+            // queries.setGameInstanceGameStageToGameOver(Sockets[socket]);
+            // io.to(Sockets[socket]).emit('disconnectTimeOut');
+          } else {
+            if (Rooms[Sockets[socket]] < 4) {
+              console.log(timer);
+              timer = timer - 1;
+              disconnectTimeOut();
+            }
+          }
+        }, 1000);
+      }
+      queries.retrieveGameInstance(Sockets[socket])
+      .then(function(game) {
+        if (game.gameStage === 'playing') {
+          disconnectTimeOut();
+        }
+      });
+    }
+
+    console.log('a user disconnected', data);
   });
 });
 

--- a/server/index.js
+++ b/server/index.js
@@ -285,8 +285,11 @@ io.on('connection', (socket) => {
         setTimeout(function(){
           if (timer === 0 && Rooms[Sockets[socket]] < 4) {
             console.log('disconnectTimeOut')
-            // queries.setGameInstanceGameStageToGameOver(Sockets[socket]);
-            // io.to(Sockets[socket]).emit('disconnectTimeOut');
+            queries.setGameInstanceGameStageToGameOver(Sockets[socket])
+            .then(function(){
+              console.log(Sockets[socket]);
+                io.to(Sockets[socket]).emit('disconnectTimeOut');
+            })
           } else {
             if (Rooms[Sockets[socket]] < 4) {
               console.log(timer);


### PR DESCRIPTION
When a player has disconnected from a game and hasn't returned after 60 seconds, the game is prematurely ended and the players who were still connected are routed to the lobby and see a message explaining what happened. 

Added Server Side:
A way to keep track of how many players are connected to a game. Lines 102-104 and 114-117 in server/index.js

An updated disconnect socket event function. This function checks when a socket disconnects if it was a part of a game, and if so, runs a check every second for 60 seconds to see if the player has reconnected. If the player does not, the gameStage of that game is set to game over and a disconnectTimeOut event is emitted.

Add Client Side:
Function to handled socket disconnectTimeOut event

PlayerDisconnected Component that displays a message explaining what happened

A new route to the lobby for displaying the above component

An update to the SendtoLobby function to allow for the reroute

<img width="861" alt="screen shot 2017-03-26 at 7 21 20 pm" src="https://cloud.githubusercontent.com/assets/22420179/24339164/f31bef48-125e-11e7-9bab-6660e80e8d70.png">
e

