### PR TITLE
Feat/rules

### DIFF
--- a/client/dist/styles.css
+++ b/client/dist/styles.css
@@ -17,6 +17,6 @@ body {
   font-size: 18px;
 }
 
-#response-item {
+#response-item, #rules {
   text-align: left;
 }

--- a/client/src/components/Rules.jsx
+++ b/client/src/components/Rules.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { Col, ListGroup, ListGroupItem } from 'react-bootstrap';
+
+const Rules = (props) => (
+  <Col>
+    <h4>Game Rules:</h4>
+    <Col id="rules">
+      <ListGroup>
+        <ListGroupItem><b>1. </b>Each round, one player will take a turn as the judge. There are 
+        four rounds, so each player will have one turn as the judge.</ListGroupItem>
+        <ListGroupItem><b>2. </b>The judge's role is to pick the funniest response submitted by the other players.</ListGroupItem>
+        <ListGroupItem><b>3. </b>If the game is a <em>User-Generated Prompt game</em>, the judge will start the round
+        by creating the prompt for that round. If the game is a <em>Random Prompt</em> game, each round's prompt
+        will be randomly generated.</ListGroupItem>
+        <ListGroupItem><b>4. </b>Then, each player will try to come up with 
+        the funniest response to the prompt.</ListGroupItem>
+        <ListGroupItem><b>5. </b> Once all players have submitted a response, the judge will select the
+        funniest response.</ListGroupItem>
+        <ListGroupItem><b>6. </b> This will repeat for four rounds until all players have taken a turn as the judge.</ListGroupItem>
+        <ListGroupItem><b>7. </b> After the fourth round, we declare the winner!</ListGroupItem>
+        <ListGroupItem><b>8. </b> Round 1 will begin 15 seconds after the fourth and final player has joined the Waiting Room. Enjoy! </ListGroupItem>
+      </ListGroup>
+    </Col>
+  </Col>
+)
+
+
+export default Rules;

--- a/client/src/components/Rules.jsx
+++ b/client/src/components/Rules.jsx
@@ -18,7 +18,7 @@ const Rules = (props) => (
         funniest response.</ListGroupItem>
         <ListGroupItem><b>6. </b> This will repeat for four rounds until all players have taken a turn as the judge.</ListGroupItem>
         <ListGroupItem><b>7. </b> After the fourth round, we declare the winner!</ListGroupItem>
-        <ListGroupItem><b>8. </b> Round 1 will begin 15 seconds after the fourth and final player has joined the Waiting Room. Enjoy! </ListGroupItem>
+        <ListGroupItem><b>8. </b> Round 1 will begin as soon as the fourth player joins the game. Enjoy!</ListGroupItem>
       </ListGroup>
     </Col>
   </Col>

--- a/client/src/components/WaitingRoom.jsx
+++ b/client/src/components/WaitingRoom.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import Rules from './Rules.jsx';
 import { Col, PageHeader, ListGroup, ListGroupItem } from 'react-bootstrap';
 
 const WaitingRoom = (props) => (
@@ -11,6 +12,9 @@ const WaitingRoom = (props) => (
       <ListGroup>
         {props.game.players.map( (player) => <ListGroupItem>{player}</ListGroupItem>)}
       </ListGroup>
+    </Col>
+    <Col sm={6} smOffset={3}>
+      <Rules/>
     </Col>
   </Col>
 )


### PR DESCRIPTION
Add the Rules component to the WaitingRoom component. Shows players the rules before the game starts.

Right now, the fourth player still won't see the Rules which is something to be fixed. I tried implementing a SetTimeout to the Game component's socket listener for 'start game', but there were issues with that since that listener is what re-renders the page to show that a fourth player has joined, so I decided to leave that out. One idea would be to have a 'Rules' button that players can click on to see the rules throughout the game. 

Here's what it looks like: 

<img width="757" alt="screen shot 2017-03-27 at 2 46 29 pm" src="https://cloud.githubusercontent.com/assets/19918128/24379618/ab437d64-12fc-11e7-8dc5-04e4ed1c9aba.png">
<img width="826" alt="screen shot 2017-03-27 at 2 46 36 pm" src="https://cloud.githubusercontent.com/assets/19918128/24379625/b1623f5a-12fc-11e7-8a98-d9cb71ebc270.png">

